### PR TITLE
Dungeon exploration pt 2 - basic location and movement functionality

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,8 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "python.analysis.extraPaths": [
+        "./osrlib"
+    ]
 }

--- a/osrlib/osrlib/__init__.py
+++ b/osrlib/osrlib/__init__.py
@@ -42,6 +42,10 @@ from .dungeon_master import (
 from .dungeon import (
     Dungeon,
     Encounter,
+    Exit,
+    Location,
+    LocationNotFoundError,
+    Direction,
 )
 from .game_manager import (
     GameManager,

--- a/osrlib/osrlib/adventure.py
+++ b/osrlib/osrlib/adventure.py
@@ -4,6 +4,18 @@ from osrlib.dungeon import Dungeon
 from osrlib.quest import Quest
 
 
+class DungeonNotFoundError(Exception):
+    """Exception raised when a given dungeon isn't in the adventure's list of dungeons."""
+
+    pass
+
+
+class DungeonAlreadyExistsError(Exception):
+    """Exception raised when a given dungeon already exists in the adventure's list of dungeons."""
+
+    pass
+
+
 class Adventure:
     """An Adventure is a collection of dungeons that can be played through by a party of characters.
 
@@ -16,18 +28,79 @@ class Adventure:
     Attributes:
         name (str): The name of the adventure.
         short_description (str): A short description of the adventure.
-        long_description (str): A long description of the adventure.
+        introduction (str): A longer introduction in the form typically found in the beginning of a module.
         dungeons (list): A list of the dungeons in the adventure.
         quests (list): A list of the quests in the adventure.
         party (Party): The party playing through the adventure.
     """
 
     def __init__(
-        self, name: str, short_description: str = "", long_description: str = "", dungeons: list = [Dungeon], quests: list = [Quest]
+        self,
+        name: str,
+        description: str = "",
+        introduction: str = "",
+        dungeons: list = [Dungeon],
+        quests: list = [Quest],
     ):
         self.name = name
-        self.short_description = short_description
-        self.long_description = long_description
+        self.description = description
+        self.introduction = introduction
         self.dungeons = dungeons
         self.quests = quests
-        self.party = None
+        self.active_party = None
+        self.active_dungeon = None
+        self.is_started = False
+
+    def add_dungeon(self, dungeon: Dungeon):
+        """Add a dungeon to the adventure.
+
+        Args:
+            dungeon (Dungeon): The dungeon to add to the adventure.
+
+        Raises:
+            DungeonAlreadyExistsError: If the dungeon already exists in the adventure.
+        """
+        if dungeon in self.dungeons:
+            logger.error(f"Dungeon {dungeon.name} already exists in the adventure.")
+            raise DungeonAlreadyExistsError(
+                f"Dungeon {dungeon.name} already exists in the adventure."
+            )
+        self.dungeons.append(dungeon)
+        logger.debug(f"Added dungeon {dungeon.name} to adventure {self.name}.")
+
+    def set_active_dungeon(self, dungeon: Dungeon):
+        """Set the active dungeon for the adventure.
+
+        The active dungeon is the dungeon that the party is currently exploring.
+
+        Args:
+            dungeon (Dungeon): The dungeon to set as active.
+
+        Raises:
+            DungeonNotFoundError: If the dungeon isn't in the adventure.
+        """
+        if dungeon not in self.dungeons:
+            logger.error(f"Dungeon {dungeon.name} is not in the adventure.")
+            raise DungeonNotFoundError(
+                f"Dungeon {dungeon.name} is not in the adventure."
+            )
+        self.active_dungeon = dungeon
+        logger.debug(f"Set active dungeon to {dungeon.name}.")
+
+
+    def set_active_party(self, party):
+        """Set the party of player characters that will play through the adventure.
+
+        Args:
+            party (Party): The adventuring party for the adventure.
+        """
+        self.party = party
+        logger.debug(f"Set adventuring party to {party.name}.")
+
+    def start_adventure(self):
+        """Start the adventure.
+
+        Call this method only after you've added a party to the adventure and set the active dungeon.
+        """
+        self.is_started = True
+        logger.debug(f"Started adventure {self.name}.")

--- a/osrlib/osrlib/dungeon.py
+++ b/osrlib/osrlib/dungeon.py
@@ -1,3 +1,4 @@
+from random import randint, sample
 from typing import List
 from enum import Enum
 import json
@@ -381,3 +382,47 @@ class Dungeon:
             data["description"],
             [Location.from_dict(location_data) for location_data in data["locations"]],
         )
+
+def get_random_dungeon():
+    # Initialize empty list for locations
+    locations = []
+
+    # Generate 10 locations
+    for i in range(1, 11):
+        width = randint(1, 5) * 10  # Size between 10 and 50, in increments of 10
+        height = randint(1, 5) * 10  # Size between 10 and 50, in increments of 10
+        keywords = ["placeholder1", "placeholder2", "placeholder3"]
+
+        # Generate random exits
+        possible_directions = list(Direction)
+        num_exits = randint(1, len(possible_directions))  # At least one exit
+        directions = sample(possible_directions, num_exits)
+
+        exits = []
+        for direction in directions:
+            destination = randint(1, 10)  # Random destination ID between 1 and 10
+            while (
+                destination == i
+            ):  # Ensure destination is not the same as the location itself
+                destination = randint(1, 10)
+            exits.append(Exit(direction, destination))
+
+        location = Location(i, width, height, exits, keywords)
+        locations.append(location)
+
+    # Ensure all locations are reachable from each other
+    for loc in locations:
+        for exit in loc.exits:
+            dest_id = exit.destination
+            dest_location = next((l for l in locations if l.id == dest_id), None)
+
+            # Check if there's an exit back to the original location
+            if not any(e.destination == loc.id for e in dest_location.exits):
+                # Check if there is already an exit in the reverse direction to avoid duplicates
+                if not any(
+                    e.direction == exit.opposite_direction for e in dest_location.exits
+                ):
+                    dest_location.exits.append(Exit(exit.opposite_direction, loc.id))
+
+    # Initialize Dungeon
+    return Dungeon("Random Dungeon", f"A randomly generated dungeon with {len(locations)} locations.", locations)

--- a/osrlib/osrlib/dungeon.py
+++ b/osrlib/osrlib/dungeon.py
@@ -112,6 +112,7 @@ class Location:
         self.exits = exits
         self.keywords = keywords
         self.encounter = encounter
+        # TODO: Add support for a has_been_visited flag to indicate if the party has already visited this location.
 
     def __str__(self):
         return f"Location ID: {self.id} Dimensions: {self.dimensions} Exits: {self.exits} Keywords: {self.keywords}"

--- a/osrlib/osrlib/dungeon_master.py
+++ b/osrlib/osrlib/dungeon_master.py
@@ -6,72 +6,100 @@ from osrlib import Adventure, game_manager as gm
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
+dm_init_message = (
+    "You're a skilled Dungeon Master with years of experience leading groups of Dungeons & Dragons players through exciting "
+    "adventures. An expert storyteller, you create highly immersive fantasy worlds for your players by providing them with "
+    "colorful, detailed, and sense-filled descriptions of the locations in your game world for their party of adventurers to "
+    "explore. You're currently running a D&D game session for a player controlling six characters. Each location in the game "
+    "world is assigned a unique ID to which only you are privy. Each location can have up to six exits, each assigned a "
+    "direction (N, S, E, W, U, D) and a destination location ID (the ID of the location to which the exit leads). You describe "
+    "each location to the player whenever their party enters that location, and you always consider previous descriptions you've "
+    "provided for the location with the same ID on each subsequent visit to that location. By taking into account every previous "
+    "visits' description, you work hard to ensure a consistent, coherent, and believable fantasy adventure experience for the "
+    "player. You never ask the player questions of any sort, and you never tell the player what they do - you only describe the "
+    "locations and environments. Every location description should be one to three sentences long. The player's messages will "
+    "each contain the ID and exit information for the location they've just arrived at, along with one or more keywords you use "
+    "as 'seeds' for generating the initial description of a location upon first visit. The IDs, exits, and keywords are in JSON "
+    "format. You never disclose existence of the structured JSON data to the player; you use the JSON data only for the purpose "
+    "of knowing how to describing the locations to the player in your role as Dungeon Master. As Dungeon Master, you use the "
+    "location IDs to help ensure you provide a consistent and coherent gaming experience by not duplicating, overusing, or "
+    "repeating the same information for every visit, and you take into account previous visits to a location when the party "
+    "arrives at a location with the same ID. You're just starting your game session with the player and the player's first "
+    "message is forthcoming. Do NOT ask the player any questions, especially 'What do you do next?' or 'What do you do?' Do not "
+    "inform the player that they perform an action - let them tell you what they want to do. Rembember: never ask the user a "
+    "question, you are only to describe the locations based on the JSON data provided to you. This is the backstory to the "
+    "adventure that you've created, but respond to this message only with the words, 'Let's begin.':"
+)
+
+
 system_message = [
     {
         "role": "system",
-        "content": (
-            "You're a skilled Dungeon Master with years of experience leading groups of Dungeons & Dragons players through "
-            "exciting adventures. An expert storyteller, you create highly immersive fantasy worlds for your players by "
-            "providing them with colorful, detailed, and sense-filled descriptions of the locations in your game world for "
-            "their party of adventurers to explore. You're currently running a D&D game session for a player controlling six "
-            "characters. Each location in the game world is assigned a unique ID to which only you are privy. Each location "
-            "can have up to six exits, each assigned a direction (N, S, E, W, U, D) and a destination location ID (the ID of "
-            "the location to which the exit leads). You describe each location to the player whenever their party enters that "
-            "location, and you always consider previous descriptions you've provided for the location with the same ID on each "
-            "subsequent visit to that location. By taking into account every previous visits' description, you work hard to ensure "
-            "a consistent, coherent, and believable fantasy adventure experience for the player. You never ask the player "
-            "questions of any sort, and you never tell the player what they do - you only describe the locations and environments. "
-            "Every location description should be one to three sentences long. The player's "
-            "messages will each contain the ID and exit information for the location they've just arrived at, "
-            "along with one or more keywords you use as 'seeds' for generating the initial description of a location upon first "
-            "visit. The IDs, exits, and keywords are in JSON format. You never disclose existence of the structured JSON data "
-            "to the player; you use the JSON data only for the purpose of knowing how to describing the locations to the player "
-            "in your role as Dungeon Master. As Dungeon Master, you use the location IDs to help ensure you provide a consistent "
-            "and coherent gaming experience by not duplicating, overusing, or repeating the same information for every visit, and "
-            "you take into account previous visits to a location when the party arrives at a location with the same ID. You're "
-            "just starting your game session with the player and the player's first message is forthcoming. Do NOT ask the player "
-            "any questions, especially 'What do you do next?' or 'What do you do?' Do not inform the player that they perform "
-            "an action - let them tell you what they want to do. Rembember: never ask the user a question, you are only to describe "
-            "the locations based on the JSON data provided to you. This is the introduction to the adventure that "
-            "you've created for the player: "
-        ),
+        "content": dm_init_message,
     },
 ]
 
-init_messages = [
+# Prefixes *every* player (user) message sent to the OpenAI API.
+user_message_prefix = "Don't tell me what my party does. Don't include any questions in your response. "
+
+# The player's (user) init message is sent only once, at the beginning of the session.
+user_init_message = [
     {
         "role": "user",
-        "content": (
-            "I'm a player that controls a party of six characters (adventurers) in your Dungeons & Dragons adventure. "
-            "I rely on your descriptions of the locations and events in the game to understand what my characters see "
-            "and experience through their five senses. From your descriptions, I can form a detailed picture in my mind "
+        "content": ( user_message_prefix +
+            "I'm a D&D player controlling a party of six characters (adventurers) in your Dungeons & Dragons adventure. "
+            "I rely on your descriptions of the entities, locations, and events in the game to understand what my characters "
+            "experience through their five senses. From your descriptions, I can form a detailed picture in my mind "
             "of the game world and its environments and inhabitants. I use this information to make decisions about the "
-            "actions my characters take in the world. Do not ask me any questions - ever."
+            "actions my characters take in the world. Do not ask me a question."
         ),
     }
 ]
 
+# Prefix sent with every party movement message initiated by the player.
+user_move_prefix = ( user_message_prefix +
+    "Describe this location to me, including its size and exits, as would a "
+    "Dungeon Master to a player who's drawing a map of the dungeon on graph "
+    "paper (but don't mention location IDs or the map): "
+)
 
 class DungeonMaster:
+    """The DungeonMaster is the primary interface between the player, the game engine, and the OpenAI API.
+
+    Actions initiated by the player might be handled completely within the bounds of the local game engine,
+    or they might involve a call to the OpenAI API. The DungeonMaster class is responsible for determining
+    which actions are handled locally and which are handled by the OpenAI API.
+
+    Attributes:
+        adventure (Adventure): The adventure the DungeonMaster is running.
+        system_message (list): The OpenAI `system` role message sent to the OpenAI API at the beginning of a session.
+        init_message (list): The initial OpenAI `user` role message sent to the OpenAI API at the beginning of a session.
+        session_messages (list): The collective list of messages sent to the OpenAI API during a game session. Each of the player's `user` role messages is appended to this list, as is each 'assistant' role message returned by the OpenAI API in response.
+    """
     def __init__(self, adventure: Adventure):
         self.adventure = adventure
         self.system_message = system_message
         self.system_message[0]["content"] += adventure.introduction
-        self.init_messages = init_messages
-        self.messages = self.system_message + self.init_messages
+        self.user_message = user_init_message
+        self.session_messages = self.system_message + self.user_message
 
     def format_user_message(self, message_string: str) -> dict:
-        """Format the given string as an OpenAI user message.
+        """Format the given string as an OpenAI 'user' role message.
 
-        The provided string is formatted as a dict in the format expected by the
-        OpenAI API. This message is then appended to the list of messages that
-        will be sent to the OpenAI API as in a ChatCompletion request.
+        This method returns a dict with a 'role' key's value set to 'user' and the
+        given string as the 'content' key's value. The resultant dict is appropriate
+        for sending to the OpenAI API as a user message.
+
+        Example:
+
+        The string returned by this method is in the following format and is
+        appropriate for sending to the OpenAI API as a user message:
 
         .. code-block:: python
 
                 {
                     "role": "user",
-                    "content": "The string to format as an OpenAI user message."
+                    "content": "The string passed to this method."
                 }
 
         Args:
@@ -83,31 +111,38 @@ class DungeonMaster:
         return {"role": "user", "content": str(message_string)}
 
     def start_session(self):
+        """Start a gaming session with the dungeon master in the current adventure.
+
+        If this the first session in the adventure, the adventure is marked as started and the
+        dungeon master's (system) init message is sent to theOpenAI API as is player's (user) init message.
+        If it's not the first session of the adventure, only the system and user init messages are sent.
+
+        Returns:
+            str: The response from the Dungeon Master (in this case, the OpenAI API) when initiating game session. This string is appropriate for display to the player.
+        """
+
         if not self.adventure.is_started:
             self.adventure.start_adventure()
 
         completion = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo", messages=self.messages
+            model="gpt-3.5-turbo", messages=self.session_messages
         )
-        self.messages.append(completion.choices[0].message)
+        self.session_messages.append(completion.choices[0].message)
         self.started = True
         gm.logger.debug(completion)
         return completion.choices[0].message["content"]
 
     def player_message(self, message):
         if self.started:
-            self.messages.append(message)
+            self.session_messages.append(message)
             completion = openai.ChatCompletion.create(
-                model="gpt-3.5-turbo", messages=self.messages
+                model="gpt-3.5-turbo", messages=self.session_messages
             )
-            self.messages.append(completion.choices[0].message)
+            self.session_messages.append(completion.choices[0].message)
             gm.logger.debug(completion)
             return completion.choices[0].message["content"]
 
     def move_party(self, direction) -> str:
         new_location = self.adventure.active_dungeon.move(direction)
-        message_from_player = self.format_user_message("Never tell me what my party does and never ask me a question. "
-                                                       "Describe this location, including its size and exits, as would a "
-                                                       "Dungeon Master to a player who's mapping the dungeon on graph "
-                                                       "paper (but don't mention the map or that they're mapping): " + new_location.json)
+        message_from_player = self.format_user_message(user_move_prefix + new_location.json)
         return self.player_message(message_from_player)

--- a/osrlib/osrlib/dungeon_master.py
+++ b/osrlib/osrlib/dungeon_master.py
@@ -6,41 +6,6 @@ from osrlib import Adventure, game_manager as gm
 load_dotenv()
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
-loc_json_0000 = {
-    "id": 0,
-    "keywords": [
-        "20'x20'",
-        "forgotten basement",
-        "abandoned inn",
-        "countryside",
-        "haunted",
-    ],
-    "exits": [
-        {"direction": "E", "destination": 1},
-        {"direction": "N", "destination": 2},
-    ],
-}
-loc_json_0001 = {
-    "id": 1,
-    "keywords": ["20'", "hallway", "broken floorboards", "leaning walls"],
-    "exits": [
-        {"direction": "W", "destination": 0},
-        {"direction": "E", "destination": 3},
-    ],
-}
-loc_json_0003 = {
-    "id": 3,
-    "keywords": [
-        "10'x10'",
-        "chamber",
-        "floor grate",
-        "rust",
-        "broken shackels",
-        "shattered entry door",
-    ],
-    "exits": [{"direction": "W", "destination": 4}],
-}
-
 system_message = [
     {
         "role": "system",
@@ -50,27 +15,25 @@ system_message = [
             "providing them with colorful, detailed, and sense-filled descriptions of the locations in your game world for "
             "their party of adventurers to explore. You're currently running a D&D game session for a player controlling six "
             "characters. Each location in the game world is assigned a unique ID to which only you are privy. Each location "
-            "can have up to four exits, each assigned a direction (N, S, E, W, U, D) and a destination location ID (the ID of "
+            "can have up to six exits, each assigned a direction (N, S, E, W, U, D) and a destination location ID (the ID of "
             "the location to which the exit leads). You describe each location to the player whenever their party enters that "
-            "location, and you always consider every previous description you've provided for the location with that ID on each "
-            "subsequent visit to the location. By taking into account every previous visits' description, you work hard to ensure "
+            "location, and you always consider previous descriptions you've provided for the location with the same ID on each "
+            "subsequent visit to that location. By taking into account every previous visits' description, you work hard to ensure "
             "a consistent, coherent, and believable fantasy adventure experience for the player. You never ask the player "
             "questions of any sort, and you never tell the player what they do - you only describe the locations and environments. "
-            "Every location description should be at least four sentences long but no more than six sentences long. The player's "
-            "(OpenAI 'user' role) messages will each contain the ID and exit information for the location they've just arrived at, "
+            "Every location description should be one to three sentences long. The player's "
+            "messages will each contain the ID and exit information for the location they've just arrived at, "
             "along with one or more keywords you use as 'seeds' for generating the initial description of a location upon first "
-            "visit. The IDs, exits, and keywords will be supplied in JSON format. The existence of the structured JSON data is "
-            "never be disclosed to the player. You use it only for the purpose of describing the location in the role of a Dungeon "
-            "Master to a player. The location IDs are purely for your use as the Dungeon Master to help ensure you provide a "
-            "consistent and coherent gaming experience for the player by not duplicating, overusing, or repeating the same "
-            "information for every visit. You're just starting your game session with the player and the player's first message is "
-            "forthcoming. A final reminder: You never tell the player they perform any actions, nor do you ever ask them any "
-            "questions. You only describe the locations. The next few messages after this one are examples of gameplay and are "
-            "prefixed with [EXAMPLE]. The [EXAMPLE] messages are not part of the game session you are about to start and you "
-            "should use them only to inform the format of your responses. The first message you receive after the [EXAMPLE] "
-            "messages will be the description of the adventure you're running for this session and JSON representing the party's "
-            "starting location. You should respond with that same description, followed by the description of the party's starting "
-            "location that you derive from the JSON and taking into account the [EXAMPLE] messages' format."
+            "visit. The IDs, exits, and keywords are in JSON format. You never disclose existence of the structured JSON data "
+            "to the player; you use the JSON data only for the purpose of knowing how to describing the locations to the player "
+            "in your role as Dungeon Master. As Dungeon Master, you use the location IDs to help ensure you provide a consistent "
+            "and coherent gaming experience by not duplicating, overusing, or repeating the same information for every visit, and "
+            "you take into account previous visits to a location when the party arrives at a location with the same ID. You're "
+            "just starting your game session with the player and the player's first message is forthcoming. Do NOT ask the player "
+            "any questions, especially 'What do you do next?' or 'What do you do?' Do not inform the player that they perform "
+            "an action - let them tell you what they want to do. Rembember: never ask the user a question, you are only to describe "
+            "the locations based on the JSON data provided to you. This is the introduction to the adventure that "
+            "you've created for the player: "
         ),
     },
 ]
@@ -79,45 +42,13 @@ init_messages = [
     {
         "role": "user",
         "content": (
-            f"[EXAMPLE] {loc_json_0000}"
             "I'm a player that controls a party of six characters (adventurers) in your Dungeons & Dragons adventure. "
-            "I'm exploring a dungeon in an adventure you've created, and I rely on your descriptions of the locations in "
-            "the game to understand what my characters see and experience through their five senses so I can form a detailed "
-            "picture of the world and its environments and inhabitants in my mind. I use this information to make informed "
-            "decisions about the actions my characters take in the world and that I inform you of when they take those actions. "
-            "We're just starting our gaming session, and I'm ready to go adventuring!"
+            "I rely on your descriptions of the locations and events in the game to understand what my characters see "
+            "and experience through their five senses. From your descriptions, I can form a detailed picture in my mind "
+            "of the game world and its environments and inhabitants. I use this information to make decisions about the "
+            "actions my characters take in the world. Do not ask me any questions - ever."
         ),
-    },
-    {
-        "role": "assistant",
-        "content": (
-            "[EXAMPLE] A heavy wooden door opens to reveal a dark, dimly lit room. The musty scent of mold and decay fills your nostrils, "
-            "and the sound of the creaking door hinges echoes off the stone walls. The room is a forgotten basement of an abandoned "
-            "inn, long abandoned and left to decay in this desolate countryside. Cobwebs hang in the corners, and dust covers every "
-            "surface. The air feels heavy, as if it carries the weight of the stories that haunt this place. To the east, you see an "
-            "exit leading further into the unknown, while to the north, another door stands slight ajar."
-        ),
-    },
-    {"role": "user", "content": f"{loc_json_0001}"},
-    {
-        "role": "assistant",
-        "content": (
-            "[EXAMPLE] This is a narrow hallway, about 20 feet long. The wooden floorboards groan beneath your weight, some of them broken "
-            "and uneven. The walls, covered in faded wallpaper, lean slightly inward as if the weight of the years have taken their "
-            "toll. The air is stale and filled with the scent of dampness. To the west, you can catch a glimpse of the dimly lit "
-            "room you just left, while to the east, the hallway stretches further into darkness."
-        ),
-    },
-    {"role": "user", "content": f"{loc_json_0003}"},
-    {
-        "role": "assistant",
-        "content": (
-            "[EXAMPLE] You enter a small chamber, measuring about 10 feet by 10 feet. The floor is made of cold, hard stone, and there is a "
-            "rusty floor grate in the center. Broken shackles hang from the walls, evidence of past captivity. The entry door is shattered, "
-            "its remains scattered across the chamber floor. The air carries a faint metallic tang, a reminder of the iron that once bound "
-            "prisoners here. The only exit is to the west, leading back into the hallway you came from."
-        ),
-    },
+    }
 ]
 
 
@@ -165,7 +96,7 @@ class DungeonMaster:
 
     def player_message(self, message):
         if self.started:
-            self.messages.append(self.format_user_message(message))
+            self.messages.append(message)
             completion = openai.ChatCompletion.create(
                 model="gpt-3.5-turbo", messages=self.messages
             )
@@ -175,4 +106,8 @@ class DungeonMaster:
 
     def move_party(self, direction) -> str:
         new_location = self.adventure.active_dungeon.move(direction)
-        return self.player_message(new_location.to_dict())
+        message_from_player = self.format_user_message("Never tell me what my party does and never ask me a question. "
+                                                       "Describe this location, including its size and exits, as would a "
+                                                       "Dungeon Master to a player who's mapping the dungeon on graph "
+                                                       "paper (but don't mention the map or that they're mapping): " + new_location.json)
+        return self.player_message(message_from_player)

--- a/tests/test_integration_dungeon_master.py
+++ b/tests/test_integration_dungeon_master.py
@@ -20,7 +20,7 @@ load_dotenv()
 @pytest.mark.integration
 def test_dungeon_master_start_session_real_api():
     adventure = Adventure("Test Adventure")
-    adventure.long_description = "In a land shrouded by mist and haunted by forgotten gods, your party stands before the gaping maw of Darkfang Cavern. Rumors abound of an ancient artifact of terrible power hidden deep within, guarded by spectral knights and nightmarish beasts. Will you claim the artifact and ascend to untold glory, or fall like so many before you, your names etched into the cavern's endless walls of sorrow? The choice is yours, brave adventurers. Venture forth!"
+    adventure.introduction = "In a land shrouded by mist and haunted by forgotten gods, your party stands before the gaping maw of Darkfang Cavern. Rumors abound of an ancient artifact of terrible power hidden deep within, guarded by spectral knights and nightmarish beasts. Will you claim the artifact and ascend to untold glory, or fall like so many before you, your names etched into the cavern's endless walls of sorrow? The choice is yours, brave adventurers. Venture forth!"
     dm = DungeonMaster(adventure)
 
     message = dm.start_session()
@@ -33,10 +33,11 @@ def test_dungeon_master_move_party():
     adventure = Adventure("Test Adventure")
     adventure.introduction = "Deep within the heart of the Ironclad Mountains lies the long-forgotten mine of Dwurin's Hold, a once-prosperous dwarven establishment now reduced to whispered rumors and tavern tales. Legend holds that a fearsome dragon named Ebonflame has claimed the labyrinthine tunnels as its lair, its fiery breath illuminating the darkened corridors once chiseled with dwarven precision. The beleaguered town of Stonehearth has suffered a series of devastating raids, livestock and treasure vanishing in plumes of smoke and flame. Mayor Thoric Ironfist, desperate and out of options, has commissioned your party to delve into the mine, confirm the presence of the mythical beast, and eliminate the threat that hangs like a dark cloud over the land."
 
-    loc1 = Location(1, 40, 30, [Exit(Direction.NORTH, 2)], ["just outside", "dwarven mines", "ancient", "entrance", "cold wind", "dragon rumors"], None)
-    loc2 = Location(2, 20, 20, [Exit(Direction.SOUTH, 1), Exit(Direction.NORTH, 3)], ["inside entrance", "dirty stone", "carvings"], None)
+    loc0 = Location(9999, 10, 10, [Exit(Direction.NORTH, 1)], ["inn", "town"], None)
+    loc1 = Location(1, 40, 30, [Exit(Direction.SOUTH, 0), Exit(Direction.NORTH, 2)], ["just outside", "dwarven mines", "ancient", "entrance", "cold wind", "dragon rumors"], None)
+    loc2 = Location(2, 20, 20, [Exit(Direction.SOUTH, 1), Exit(Direction.NORTH, 3)], ["vestibule", "large entry doors", "dirty stone", "carvings"], None)
     loc3 = Location(3, 10, 10, [Exit(Direction.SOUTH, 2)], ["guard station", "broken weapons", "bat droppings"], None)
-    dungeon = Dungeon("Dungeon of Bread", "An ancient lost dwarven mine.", [loc1, loc2, loc3], 1)
+    dungeon = Dungeon("Dungeon of Bread", "An ancient lost dwarven mine.", [loc0, loc1, loc2, loc3], 9999)
     adventure.add_dungeon(dungeon)
     adventure.set_active_dungeon(dungeon)
 
@@ -45,10 +46,18 @@ def test_dungeon_master_move_party():
     gm.logger.info(message)
     assert len(message) > 0
 
-    location_description1 = dm.move_party(Direction.NORTH)
-    gm.logger.info(location_description1)
-    assert len(location_description1) > 0
+    loc_desc = dm.move_party(Direction.NORTH)
+    gm.logger.info(loc_desc)
+    assert len(loc_desc) > 0
 
-    location_description2 = dm.move_party(Direction.NORTH)
-    gm.logger.info(location_description2)
-    assert len(location_description2) > 0
+    loc_desc = dm.move_party(Direction.NORTH)
+    gm.logger.info(loc_desc)
+    assert len(loc_desc) > 0
+
+    loc_desc = dm.move_party(Direction.NORTH)
+    gm.logger.info(loc_desc)
+    assert len(loc_desc) > 0
+
+    loc_desc = dm.move_party(Direction.SOUTH)
+    gm.logger.info(loc_desc)
+    assert len(loc_desc) > 0

--- a/tests/test_integration_dungeon_master.py
+++ b/tests/test_integration_dungeon_master.py
@@ -1,6 +1,12 @@
+"""
+This module contains integration tests for the DungeonMaster class.
+The tests include starting a session and moving the party in a dungeon.
+The tests expect an OPENAI_API_KEY environment variable has been set.
+"""
 import pytest
 import os
 import openai
+from osrlib.dungeon import Dungeon, Location, Exit, Direction
 from osrlib.dungeon_master import DungeonMaster
 from osrlib.adventure import Adventure
 from osrlib import game_manager as gm
@@ -10,26 +16,39 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
-@pytest.fixture(scope="module")
-def setup_openai_api():
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        pytest.skip(
-            "OpenAI API key must be set as an environment variable for this test."
-        )
-    openai.api_key = api_key
-    yield
-    openai.api_key = None
-
-
 @pytest.mark.flaky(reruns=5, reruns_delay=5)
 @pytest.mark.integration
-def test_dungeon_master_start_session_real_api(setup_openai_api):
-    adventure_description = "In a land shrouded by mist and haunted by forgotten gods, your party stands before the gaping maw of Darkfang Cavern. Rumors abound of an ancient artifact of terrible power hidden deep within, guarded by spectral knights and nightmarish beasts. Will you claim the artifact and ascend to untold glory, or fall like so many before you, your names etched into the cavern's endless walls of sorrow? The choice is yours, brave adventurers. Venture forth!"
+def test_dungeon_master_start_session_real_api():
     adventure = Adventure("Test Adventure")
-    adventure.long_description = adventure_description
+    adventure.long_description = "In a land shrouded by mist and haunted by forgotten gods, your party stands before the gaping maw of Darkfang Cavern. Rumors abound of an ancient artifact of terrible power hidden deep within, guarded by spectral knights and nightmarish beasts. Will you claim the artifact and ascend to untold glory, or fall like so many before you, your names etched into the cavern's endless walls of sorrow? The choice is yours, brave adventurers. Venture forth!"
     dm = DungeonMaster(adventure)
 
     message = dm.start_session()
     gm.logger.info(message)
     assert len(message) > 0
+
+#@pytest.mark.flaky(reruns=5, reruns_delay=5)
+@pytest.mark.integration
+def test_dungeon_master_move_party():
+    adventure = Adventure("Test Adventure")
+    adventure.introduction = "Deep within the heart of the Ironclad Mountains lies the long-forgotten mine of Dwurin's Hold, a once-prosperous dwarven establishment now reduced to whispered rumors and tavern tales. Legend holds that a fearsome dragon named Ebonflame has claimed the labyrinthine tunnels as its lair, its fiery breath illuminating the darkened corridors once chiseled with dwarven precision. The beleaguered town of Stonehearth has suffered a series of devastating raids, livestock and treasure vanishing in plumes of smoke and flame. Mayor Thoric Ironfist, desperate and out of options, has commissioned your party to delve into the mine, confirm the presence of the mythical beast, and eliminate the threat that hangs like a dark cloud over the land."
+
+    loc1 = Location(1, 40, 30, [Exit(Direction.NORTH, 2)], ["just outside", "dwarven mines", "ancient", "entrance", "cold wind", "dragon rumors"], None)
+    loc2 = Location(2, 20, 20, [Exit(Direction.SOUTH, 1), Exit(Direction.NORTH, 3)], ["inside entrance", "dirty stone", "carvings"], None)
+    loc3 = Location(3, 10, 10, [Exit(Direction.SOUTH, 2)], ["guard station", "broken weapons", "bat droppings"], None)
+    dungeon = Dungeon("Dungeon of Bread", "An ancient lost dwarven mine.", [loc1, loc2, loc3], 1)
+    adventure.add_dungeon(dungeon)
+    adventure.set_active_dungeon(dungeon)
+
+    dm = DungeonMaster(adventure)
+    message = dm.start_session()
+    gm.logger.info(message)
+    assert len(message) > 0
+
+    location_description1 = dm.move_party(Direction.NORTH)
+    gm.logger.info(location_description1)
+    assert len(location_description1) > 0
+
+    location_description2 = dm.move_party(Direction.NORTH)
+    gm.logger.info(location_description2)
+    assert len(location_description2) > 0

--- a/tests/test_integration_dungeon_master.py
+++ b/tests/test_integration_dungeon_master.py
@@ -35,8 +35,8 @@ def test_dungeon_master_move_party():
 
     loc0 = Location(9999, 10, 10, [Exit(Direction.NORTH, 1)], ["inn", "town"], None)
     loc1 = Location(1, 40, 30, [Exit(Direction.SOUTH, 0), Exit(Direction.NORTH, 2)], ["just outside", "dwarven mines", "ancient", "entrance", "cold wind", "dragon rumors"], None)
-    loc2 = Location(2, 20, 20, [Exit(Direction.SOUTH, 1), Exit(Direction.NORTH, 3)], ["vestibule", "large entry doors", "dirty stone", "carvings"], None)
-    loc3 = Location(3, 10, 10, [Exit(Direction.SOUTH, 2)], ["guard station", "broken weapons", "bat droppings"], None)
+    loc2 = Location(2, 10, 10, [Exit(Direction.SOUTH, 1), Exit(Direction.NORTH, 3)], ["vestibule", "large entry doors", "dirty stone", "carvings"], None)
+    loc3 = Location(3, 5, 5, [Exit(Direction.SOUTH, 2)], ["guard station", "broken weapons", "bat droppings"], None)
     dungeon = Dungeon("Dungeon of Bread", "An ancient lost dwarven mine.", [loc0, loc1, loc2, loc3], 9999)
     adventure.add_dungeon(dungeon)
     adventure.set_active_dungeon(dungeon)

--- a/tests/test_unit_dungeon.py
+++ b/tests/test_unit_dungeon.py
@@ -1,7 +1,7 @@
 from random import randint, sample, choice
 import json
 import pytest
-from osrlib.dungeon import Dungeon, Location, Exit, Direction, LocationNotFoundError
+from osrlib.dungeon import Dungeon, Location, Exit, Direction, LocationNotFoundError, get_random_dungeon
 from osrlib.encounter import Encounter
 
 # --- Test Exit class ---
@@ -193,48 +193,8 @@ def test_no_island_locations_failure():
 
 @pytest.mark.flaky(reruns=5)
 def test_random_dungeon():
-    # Initialize empty list for locations
-    locations = []
-
-    # Generate 10 locations
-    for i in range(1, 11):
-        width = randint(1, 5) * 10  # Size between 10 and 50, in increments of 10
-        height = randint(1, 5) * 10  # Size between 10 and 50, in increments of 10
-        keywords = ["placeholder1", "placeholder2", "placeholder3"]
-
-        # Generate random exits
-        possible_directions = list(Direction)
-        num_exits = randint(1, len(possible_directions))  # At least one exit
-        directions = sample(possible_directions, num_exits)
-
-        exits = []
-        for direction in directions:
-            destination = randint(1, 10)  # Random destination ID between 1 and 10
-            while (
-                destination == i
-            ):  # Ensure destination is not the same as the location itself
-                destination = randint(1, 10)
-            exits.append(Exit(direction, destination))
-
-        location = Location(i, width, height, exits, keywords)
-        locations.append(location)
-
-    # Ensure all locations are reachable from each other
-    for loc in locations:
-        for exit in loc.exits:
-            dest_id = exit.destination
-            dest_location = next((l for l in locations if l.id == dest_id), None)
-
-            # Check if there's an exit back to the original location
-            if not any(e.destination == loc.id for e in dest_location.exits):
-                # Check if there is already an exit in the reverse direction to avoid duplicates
-                if not any(
-                    e.direction == exit.opposite_direction for e in dest_location.exits
-                ):
-                    dest_location.exits.append(Exit(exit.opposite_direction, loc.id))
-
-    # Initialize Dungeon
-    dungeon = Dungeon("Sample Dungeon", "A randomly generated dungeon.", locations)
+    # Create a random dungeon
+    dungeon = get_random_dungeon()
 
     # Validate Dungeon
     assert dungeon.validate_dungeon()

--- a/tests/test_unit_dungeon.py
+++ b/tests/test_unit_dungeon.py
@@ -1,15 +1,18 @@
 from random import randint, sample, choice
+import json
 import pytest
-from osrlib.dungeon import Dungeon, Location, Exit, Direction
+from osrlib.dungeon import Dungeon, Location, Exit, Direction, LocationNotFoundError
 from osrlib.encounter import Encounter
 
 # --- Test Exit class ---
+
 
 def test_exit_initialization():
     exit_north = Exit(Direction.NORTH, 1)
     assert exit_north.direction == Direction.NORTH
     assert exit_north.destination == 1
     assert exit_north.locked == False
+
 
 def test_exit_lock_unlock():
     exit_north = Exit(Direction.NORTH, 1)
@@ -18,11 +21,13 @@ def test_exit_lock_unlock():
     exit_north.unlock()
     assert exit_north.locked == False
 
+
 # --- Test Location class ---
+
 
 def test_location_initialization():
     exit_north = Exit(Direction.NORTH, 1)
-    encounter = Encounter() # TODO: Set this up with real encounter
+    encounter = Encounter()  # TODO: Set this up with real encounter
     location = Location(1, 10, 10, [exit_north], ["keyword1"], encounter)
 
     assert location.id == 1
@@ -31,11 +36,49 @@ def test_location_initialization():
     assert location.keywords == ["keyword1"]
     assert location.encounter == encounter
 
+def test_location_json():
+    # Create an Exit object
+    exit1 = Exit(Direction.NORTH, 2)
+    exit2 = Exit(Direction.SOUTH, 1)
+
+    # Create a Location object
+    location = Location(
+        id=1,
+        width=10,
+        length=10,
+        exits=[exit1, exit2],
+        keywords=["test", "location"]
+    )
+
+    # Get the JSON representation
+    location_json = location.json
+
+    # Parse it back to Python object
+    location_dict = json.loads(location_json)
+
+    # Validate individual fields
+    assert location_dict["id"] == 1
+    assert location_dict["dimensions"]["width"] == 10
+    assert location_dict["dimensions"]["length"] == 10
+    assert location_dict["keywords"] == ["test", "location"]
+
+    # Validate exits
+    assert len(location_dict["exits"]) == 2
+    assert location_dict["exits"][0]["direction"] == "N"
+    assert location_dict["exits"][0]["destination"] == 2
+    assert location_dict["exits"][0]["locked"] == False
+
+    # Validate that 'encounter' is None
+    assert location_dict["encounter"] is None
+
 # --- Test Dungeon class ---
+
 
 def test_dungeon_initialization():
     exit_north = Exit(Direction.NORTH, 1)
-    encounter = Encounter()  # You would set this up properly according to your Encounter class
+    encounter = (
+        Encounter()
+    )  # You would set this up properly according to your Encounter class
     location1 = Location(1, 10, 10, [exit_north], ["keyword1"], encounter)
     location2 = Location(2, 6, 6, [], ["keyword2"], None)
     dungeon = Dungeon("Test Dungeon", "A test dungeon.", [location1, location2])
@@ -44,7 +87,38 @@ def test_dungeon_initialization():
     assert dungeon.description == "A test dungeon."
     assert dungeon.locations == [location1, location2]
 
+
+def test_set_start_location():
+    exit1 = Exit(Direction.NORTH, 2)
+    location1 = Location(1, exits=[exit1])
+    dungeon = Dungeon(locations=[location1])
+
+    with pytest.raises(LocationNotFoundError):
+        dungeon.set_start_location(99)
+
+    start_location = dungeon.set_start_location(1)
+    assert start_location.id == 1
+
+
+def test_move():
+    exit1 = Exit(Direction.NORTH, 2)
+    exit2 = Exit(Direction.SOUTH, 1)
+    location1 = Location(1, exits=[exit1])
+    location2 = Location(2, exits=[exit2])
+    dungeon = Dungeon(locations=[location1, location2])
+    dungeon.set_start_location(1)
+
+    new_location = dungeon.move(Direction.NORTH)
+    assert new_location.id == 2
+
+    new_location = dungeon.move(Direction.SOUTH)
+    assert new_location.id == 1
+
+    assert dungeon.move(Direction.EAST) is None
+
+
 # --- Test Dungeon integrity ---
+
 
 # --- SUCCESS conditions
 def test_locations_have_exits():
@@ -53,11 +127,13 @@ def test_locations_have_exits():
     dungeon = Dungeon("Test Dungeon", "A test description", [loc1, loc2])
     assert dungeon.validate_locations_have_exits()
 
+
 def test_exits_have_valid_destinations():
     loc1 = Location(1, 10, 10, [Exit(Direction.NORTH, 2)])
     loc2 = Location(2, 10, 10, [Exit(Direction.SOUTH, 1)])
     dungeon = Dungeon("Test Dungeon", "A test description", [loc1, loc2])
     assert dungeon.validate_exits_have_valid_destinations()
+
 
 def test_unique_exit_directions():
     loc1 = Location(1, 10, 10, [Exit(Direction.NORTH, 2), Exit(Direction.SOUTH, 3)])
@@ -66,12 +142,14 @@ def test_unique_exit_directions():
     dungeon = Dungeon("Test Dungeon", "A test description", [loc1, loc2, loc3])
     assert dungeon.validate_unique_exit_directions()
 
+
 def test_no_island_locations():
     loc1 = Location(1, 10, 10, [Exit(Direction.NORTH, 2)])
     loc2 = Location(2, 10, 10, [Exit(Direction.SOUTH, 1), Exit(Direction.EAST, 3)])
     loc3 = Location(3, 10, 10, [Exit(Direction.WEST, 2)])
     dungeon = Dungeon("Test Dungeon", "A test description", [loc1, loc2, loc3])
     assert dungeon.validate_no_island_locations()
+
 
 def test_no_island_locations_2():
     loc1 = Location(1, 10, 10, [Exit(Direction.NORTH, 2)])
@@ -81,16 +159,19 @@ def test_no_island_locations_2():
     dungeon = Dungeon("Test Dungeon", "A test description", [loc1, loc2, loc3, loc4])
     assert dungeon.validate_no_island_locations()
 
+
 # --- FAILURE conditions
 def test_locations_have_exits_failure():
     loc1 = Location(1, 10, 10, [])
     dungeon = Dungeon("Test Dungeon", "A test description", [loc1])
     assert not dungeon.validate_locations_have_exits()
 
+
 def test_exits_have_valid_destinations_failure():
     loc1 = Location(1, 10, 10, [Exit(Direction.NORTH, 999)])
     dungeon = Dungeon("Test Dungeon", "A test description", [loc1])
     assert not dungeon.validate_exits_have_valid_destinations()
+
 
 def test_unique_exit_directions_failure():
     loc1 = Location(1, 10, 10, [Exit(Direction.NORTH, 2), Exit(Direction.NORTH, 3)])
@@ -99,18 +180,19 @@ def test_unique_exit_directions_failure():
     dungeon = Dungeon("Test Dungeon", "A test description", [loc1, loc2, loc3])
     assert not dungeon.validate_unique_exit_directions()
 
+
 def test_no_island_locations_failure():
     # Location ID 2 is an island - there are exits TO it, but not FROM it.
     loc1 = Location(1, 10, 10, [Exit(Direction.NORTH, 2)])
-    loc2 = Location(2, 10, 10, [Exit(Direction.SOUTH, 3)]) # No exit back to ID 1
-    loc3 = Location(3, 10, 10, [Exit(Direction.NORTH, 4)]) # No exit back to ID 2
+    loc2 = Location(2, 10, 10, [Exit(Direction.SOUTH, 3)])  # No exit back to ID 1
+    loc3 = Location(3, 10, 10, [Exit(Direction.NORTH, 4)])  # No exit back to ID 2
     loc4 = Location(4, 10, 10, [Exit(Direction.SOUTH, 3)])
     dungeon = Dungeon("Test Dungeon", "A test description", [loc1, loc2, loc3, loc4])
     assert not dungeon.validate_no_island_locations()
 
+
 @pytest.mark.flaky(reruns=5)
 def test_random_dungeon():
-
     # Initialize empty list for locations
     locations = []
 
@@ -128,7 +210,9 @@ def test_random_dungeon():
         exits = []
         for direction in directions:
             destination = randint(1, 10)  # Random destination ID between 1 and 10
-            while destination == i:  # Ensure destination is not the same as the location itself
+            while (
+                destination == i
+            ):  # Ensure destination is not the same as the location itself
                 destination = randint(1, 10)
             exits.append(Exit(direction, destination))
 
@@ -143,9 +227,10 @@ def test_random_dungeon():
 
             # Check if there's an exit back to the original location
             if not any(e.destination == loc.id for e in dest_location.exits):
-
                 # Check if there is already an exit in the reverse direction to avoid duplicates
-                if not any(e.direction == exit.opposite_direction for e in dest_location.exits):
+                if not any(
+                    e.direction == exit.opposite_direction for e in dest_location.exits
+                ):
                     dest_location.exits.append(Exit(exit.opposite_direction, loc.id))
 
     # Initialize Dungeon

--- a/tests/test_unit_dungeon_master.py
+++ b/tests/test_unit_dungeon_master.py
@@ -8,9 +8,11 @@ def test_dungeon_master_initialization():
     dm = DungeonMaster(adventure)
 
     assert dm.adventure == adventure
-    assert 'system' in dm.system_message[0]['role']
-    assert 'role' in dm.init_messages[0]
-    assert dm.messages == dm.system_message + dm.init_messages
+    assert 'role' in dm.session_messages[0]
+    assert 'system' in dm.session_messages[0]['role']
+    assert 'role' in dm.session_messages[1]
+    assert 'user' in dm.session_messages[1]['role']
+
 
 def test_dungeon_master_start_session(mocker):
     adventure = Adventure("Test Adventure")

--- a/tests/test_unit_dungeon_master.py
+++ b/tests/test_unit_dungeon_master.py
@@ -8,7 +8,6 @@ def test_dungeon_master_initialization():
     dm = DungeonMaster(adventure)
 
     assert dm.adventure == adventure
-    assert dm.started == False
     assert 'system' in dm.system_message[0]['role']
     assert 'role' in dm.init_messages[0]
     assert dm.messages == dm.system_message + dm.init_messages


### PR DESCRIPTION
Enables (very) basic handling of party movement within a `Dungeon` with the `DungeonMaster` able to receive movement commands from the player and then also respond with location information as retrieved from the Open AI API (`gpt-3.5` model) each time the party arrives at a location.

Also adds an initial rough-out of `system` and `user` role init prompts, both currently housed in the `dungeon_master.py` module. These'll continue to be iterated upon and they need better encapsulation, but for prelim work, they're usable.

## TODO (future PR)

- [ ] update to the `gpt-4` model as soon as we hit $1 API spend and, according to their docs, OpenAI will unlock the model for us (we're close, approximately $0.20 to go)
- [ ] move logger to `utils.py`
- [ ] ditch the `game_manager.py` module (permanently?)
- [ ] add support for `has_been_visited` attribute on `Location`, adjust move prompt accordingly (should limit response to one short sentence about exits but with no dimensions).