### PR TITLE
docstring pass on dungeon, inventory, party modules

### DIFF
--- a/docs/reference/constants.md
+++ b/docs/reference/constants.md
@@ -6,3 +6,5 @@
 ::: osrlib.constants.HALFLING_NAMES
 ::: osrlib.constants.MAGIC_USER_NAMES
 ::: osrlib.constants.THIEF_NAMES
+::: osrlib.constants.ADVENTURE_NAMES
+::: osrlib.constants.DUNGEON_NAMES

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ extra_css:
   - "main.css"
 
 plugins:
+  - search
   - mkdocstrings:
       handlers:
         python:

--- a/osrlib/osrlib/dungeon.py
+++ b/osrlib/osrlib/dungeon.py
@@ -112,7 +112,7 @@ class Exit:
 
     @classmethod
     def from_dict(cls, data):
-        """Deserializes a dictionary representation of a `Exit` object. Typically done after getting the dictionary from persistent storage."""
+        """Deserializes a dictionary representation of an `Exit` object. Typically done after getting the dictionary from persistent storage."""
         return cls(Direction(data["direction"]), data["destination"], data["locked"])
 
 

--- a/osrlib/osrlib/inventory.py
+++ b/osrlib/osrlib/inventory.py
@@ -1,3 +1,5 @@
+"""The `inventory` module includes the [Inventory][osrlib.inventory.Inventory] class which backs the `inventory` attribute of a [PlayerCharacter][osrlib.player_character.PlayerCharacter]."""
+
 from collections import defaultdict
 from typing import List
 
@@ -28,15 +30,18 @@ class Inventory:
         owner (PlayerCharacter): Owner of the inventory.
 
     Example:
-        >>> pc = PlayerCharacter()
-        >>> inv = Inventory(pc)
+
+    ```python
+    >>> pc = PlayerCharacter()
+    >>> inv = Inventory(pc)
+    ```
     """
 
     def __init__(self, player_character_owner: "PlayerCharacter"):
-        """Initialize a PlayerCharacter's inventory.
+        """Creates a `PlayerCharacter` instance.
 
         Args:
-            owner (PlayerCharacter): The player character that owns the inventory.
+            player_character_owner (PlayerCharacter): The player character that owns the inventory.
         """
         self.items: defaultdict[ItemType, List[Item]] = defaultdict(list)
         self.owner = player_character_owner
@@ -146,13 +151,13 @@ class Inventory:
         else:
             raise ItemNotEquippedError(f"Can't unequip item '{item.name}' because it is not currently equipped.")
 
-    def drop_all_items(self):
+    def drop_all_items(self) -> List[Item]:
         """Remove all items from the inventory and return a collection of the items that were removed.
 
         Equipped items are unequipped prior to being removed.
 
         Returns:
-            list[Item]: List of all items that were removed.
+            List of all items that were removed.
         """
         removed_items = []
         for item in self.all_items:
@@ -165,38 +170,38 @@ class Inventory:
         return removed_items
 
     @property
-    def all_items(self):
+    def all_items(self) -> List[Item]:
         """Gets all items stored in the items defaultdict inventory property.
 
         Returns:
-            list[Item]: List of all items.
+            List of all items in the inventory.
         """
         return [item for sublist in self.items.values() for item in sublist]
 
     @property
-    def equipped_items(self):
+    def equipped_items(self) -> List[Item]:
         """Get all equipped items in the inventory.
 
         Returns:
-            list[Item]: List of equipped items. Returns an empty list if no equipped items are present.
+            List of equipped items. Returns an empty list if no equipped items are present.
         """
         return [item for item in self.all_items if item.is_equipped]
 
     @property
-    def armor(self):
+    def armor(self) -> List[Armor]:
         """Gets all armor items stored in the items defaultdict inventory property.
 
         Returns:
-            list[Item]: List of armor items. Returns an empty list if no armor items are present.
+            List of armor items. Returns an empty list if no armor items are present.
         """
         return self.items[ItemType.ARMOR]
 
     @property
-    def weapons(self):
+    def weapons(self) -> List[Weapon]:
         """Gets all weapon items stored in the items defaultdict inventory property.
 
         Returns:
-            list[Item]: List of weapon items. Returns an empty list if no weapon items are present.
+            List of weapon items. Returns an empty list if no weapon items are present.
         """
         return self.items[ItemType.WEAPON]
 
@@ -209,44 +214,45 @@ class Inventory:
         return next((weapon for weapon in self.weapons if weapon.is_equipped), Weapon("Fists", "1d1"))
 
     @property
-    def spells(self):
+    def spells(self) -> List[Spell]:
         """Gets all spell items stored in the items defaultdict inventory property.
 
         Returns:
-            list[Item]: List of spell items. Returns an empty list if no spell items are present.
+            List of spell items. Returns an empty list if no spell items are present.
         """
         return self.items[ItemType.SPELL]
 
     @property
-    def equipment(self):
+    def equipment(self) -> List[Item]:
         """Gets all equipment items stored in the items defaultdict inventory property.
 
         Returns:
-            list[Item]: List of equipment items. Returns an empty list if no equipment items are present.
+            List of equipment items. Returns an empty list if no equipment items are present.
         """
         return self.items[ItemType.EQUIPMENT]
 
     @property
-    def magic_items(self):
+    def magic_items(self) -> List[Item]:
         """Gets all magic items stored in the items defaultdict inventory property.
 
         Returns:
-            list[Item]: List of magic items. Returns an empty list if no magic items are present.
+            List of magic items. Returns an empty list if no magic items are present.
         """
         return self.items[ItemType.MAGIC_ITEM]
 
     @property
-    def misc_items(self):
+    def misc_items(self) -> List[Item]:
         """Gets all miscellaneous items stored in the items defaultdict inventory property.
 
         Miscellaneous items include items that are not armor, weapons, spells, equipment, or magic items.
 
         Returns:
-            list[Item]: List of miscellaneous items. Returns an empty list if no miscellaneous items are present.
+            List of miscellaneous items. Returns an empty list if no miscellaneous items are present.
         """
         return self.items[ItemType.ITEM]
 
     def to_dict(self) -> dict:
+        """Serializes the `Inventory` to a dictionary, typically in preparation for writing it to persistent storage in a downstream operation."""
         return {
             "items": [item.to_dict() for item in self.all_items],
             "owner": self.owner.name,
@@ -254,10 +260,11 @@ class Inventory:
 
     @classmethod
     def from_dict(cls, inventory_dict: dict, player_character_owner: "PlayerCharacter") -> "Inventory":
-        """Converts a dictionary to an inventory.
+        """Deserializes a dictionary representation of an `Inventory` object. Typically done after getting the dictionary from persistent storage.
 
         Args:
             inventory_dict (dict): Dictionary representation of the inventory.
+            player_character_owner (PlayerCharacter): The player character that owns the inventory.
         """
         player_character_owner.inventory = Inventory(player_character_owner)
 

--- a/osrlib/osrlib/item.py
+++ b/osrlib/osrlib/item.py
@@ -1,4 +1,4 @@
-"""Classes that represent items in the game and player character (PC) inventory."""
+"""The `item` module includes classes that represent items in the game like weapons, armor, spells, and regular adventuring gear."""
 from enum import Enum
 from typing import Optional, Set
 
@@ -69,8 +69,12 @@ class Item:
         quest (Optional[Quest]): The quest that the item is a part of.
 
     Example:
-        >>> usable_by = {CharacterClassType.FIGHTER, CharacterClassType.THIEF}
-        >>> item = Item("Sword", ItemType.WEAPON, usable_by, max_equipped=1, gp_value=10)
+
+    ```python
+    # Create an item that is a sword usable by fighters and thieves
+    usable_by = {CharacterClassType.FIGHTER, CharacterClassType.THIEF}
+    item = Item("Sword", ItemType.WEAPON, usable_by, max_equipped=1, gp_value=10)
+    ```
     """
 
     def __init__(
@@ -223,7 +227,11 @@ class Armor(Item):
         and a negative number increases AC (bad). Defaults to 1.
 
     Example:
-        >>> armor = Armor("Plate Mail", ac_modifier=7)
+
+    ```python
+    # Create a suit of plate mail
+    armor = Armor("Plate Mail", ac_modifier=7)
+    ```
     """
 
     def __init__(self, name: str, ac_modifier: int = -1, **kwargs):
@@ -267,6 +275,9 @@ class Armor(Item):
 class Weapon(Item):
     """Represents a weapon item in the game.
 
+    The Weapon class extends the Item class to represent weapons in the game. It specifies damage die and may have a
+    range indicating how far it can attack. Melee weapons typically have `None` as their range value.
+
     Args:
         name (str): The name of the weapon.
         to_hit_damage_die (str, optional): The to-hit and damage roll for the weapon. Defaults to '1d4'.
@@ -277,14 +288,13 @@ class Weapon(Item):
         damage_die (str): The damage die for the weapon, formatted like '1d8', '2d4', '1d6+1', etc.
         range (Optional[int]): The range of the weapon in feet.
 
-    Note:
-        The Weapon class extends the Item class to represent weapons in the game.
-        It specifies damage die and may have a range indicating how far it can attack.
-        Melee weapons typically have `None` as their range value.
-
     Example:
-        >>> sword = Weapon(name="Longsword", to_hit_damage_die="1d8")
-        >>> enchanted_bow = Weapon(name="Longbow of Accuracy", to_hit_damage_die="1d8+1", range=150)
+
+    ```python
+    # Create a sword and a longbow +1
+    sword = Weapon(name="Longsword", to_hit_damage_die="1d8")
+    enchanted_bow = Weapon(name="Longbow of Accuracy", to_hit_damage_die="1d8+1", range=150)
+    ```
     """
 
     def __init__(
@@ -351,8 +361,12 @@ class Spell(Item):
         instantaneous spell.
 
     Example:
-        >>> fireball = Spell(name="Fireball", spell_level=3, damage_die="8d6", range=150, duration_minutes=None)
-        >>> heal = Spell(name="Heal", spell_level=6, damage_die=None, range=None, duration_minutes=10)
+
+    ```python
+    # Create two spells, one of 3rd-level (fireball) and another of 6th-level (heal)
+    fireball = Spell(name="Fireball", spell_level=3, damage_die="8d6", range=150, duration_minutes=None)
+    heal = Spell(name="Heal", spell_level=6, damage_die=None, range=None, duration_minutes=10)
+    ```
     """
 
     def __init__(

--- a/osrlib/osrlib/party.py
+++ b/osrlib/osrlib/party.py
@@ -1,5 +1,5 @@
-"""The Party module contains the Party class and functions related to managing a party of player characters (collection
-of type PlayerCharacter)."""
+"""The party module contains the [Party][osrlib.party.Party] class and functions related to managing a party of player characters (collection
+of [PlayerCharacter][osrlib.player_character.PlayerCharacter])."""
 
 import random
 from typing import List
@@ -29,12 +29,14 @@ class CharacterAlreadyInPartyError(Exception):
     """Raised when attempting to add a player character to a party that already has that character as a member.
 
     Example:
-        Before trying to add a character to a party, check whether the character is already in the party by using the in
-        operator:
 
-        .. code-block:: python
-            if not party.is_member(some_new_character):
-                party.add_character(some_new_character)
+    Before trying to add a character to a party, check whether the character is already in the party by using the in
+    operator:
+
+    ```python
+    if not party.is_member(some_new_character):
+        party.add_character(some_new_character)
+    ```
     """
 
     pass
@@ -44,12 +46,14 @@ class CharacterNotInPartyError(Exception):
     """Raised when attempting to remove a player character from a party that does not have the character as a member.
 
     Example:
-        Before trying to remove a character from a party, check whether the character is in the party by using the ``in``
-        operator:
 
-        .. code-block:: python
-            if character in party:
-            party.remove_character(character)
+    Before trying to remove a character from a party, check whether the character is in the party by using the ``in``
+    operator:
+
+    ```python
+    if character in party:
+        party.remove_character(character)
+    ```
     """
 
     pass
@@ -147,10 +151,11 @@ class Party:
         character.
 
         Example:
-            Create a new character and add them to the party:
 
-            .. code-block:: python
-                party.create_character("Sckricko", character_classes.CharacterClassType.FIGHTER, 1)
+        ```python
+        # Create a new character and add them to the party
+        party.create_character("Sckricko", character_classes.CharacterClassType.FIGHTER, 1)
+        ```
 
         Args:
             name (str): The name of the character.
@@ -182,16 +187,17 @@ class Party:
         A character can be added to a party only once, and a party has a maximum number of characters.
 
         Example:
-            Add a character to a party and allow them to be set as the active character:
 
-            .. code-block:: python
-                fighter = PlayerCharacter("Sckricko", character_classes.CharacterClassType.FIGHTER, 1)
-                thief = PlayerCharacter("Slick", character_classes.CharacterClassType.THIEF, 1)
-                party.add_character(fighter)  # sets the character as active for the party character by default
-                party.add_character(thief, set_as_active_character=False)  # don't set the character as active for the
-                                                                        # party
-                if party.active_character == fighter:
-                    print(f"Character '{character.name}' is the active character in the party.")
+        ```python
+        # Add a character to a party and allow them to be set as the active character
+        fighter = PlayerCharacter("Sckricko", character_classes.CharacterClassType.FIGHTER, 1)
+        thief = PlayerCharacter("Slick", character_classes.CharacterClassType.THIEF, 1)
+        party.add_character(fighter) # sets the character as active for the party character by default
+        party.add_character(thief, set_as_active_character=False) # don't set the character as active for the party
+
+        if party.active_character == fighter:
+            print(f"Character '{character.name}' is the active character in the party.")
+        ```
 
         Args:
             character (PlayerCharacter): The PC to add to the party.
@@ -240,13 +246,13 @@ class Party:
 
         Example:
 
-            Check whether a character is in the party:
-
-            .. code-block:: python
-                if party.is_member(some_player_character):
-                    print(f"{some_name} is in the party.")
-                else:
-                    print(f"{some_name} is not in the party.")
+        ```python
+        # Check whether a character is in the party
+        if party.is_member(some_player_character):
+            print(f"{some_name} is in the party.")
+        else:
+            print(f"{some_name} is not in the party.")
+        ```
 
         Args:
             character (PlayerCharacter): The character to check for.
@@ -284,8 +290,9 @@ class Party:
 
         Example:
 
-                .. code-block:: python
-                    party.set_next_character_as_active()
+            ```python
+            party.set_next_character_as_active()
+            ```
         """
         if not self.members or len(self.members) == 0:
             # Handle the case where there are no members in the party
@@ -310,11 +317,13 @@ class Party:
         If the character is the last in the party, the party's active character is set to None.
 
         Example:
-        .. code-block:: python
-            try:
-                party.remove_character(character)
-            except CharacterNotInPartyError:
-                print(f"Character '{character.name}' wasn't in the party and thus couldn't be removed from it.")
+
+        ```python
+        try:
+            party.remove_character(character)
+        except CharacterNotInPartyError:
+            print(f"Character '{character.name}' wasn't in the party and thus couldn't be removed from it.")
+        ```
 
         Args:
             character (PlayerCharacter): The PC to remove from the party.
@@ -332,10 +341,11 @@ class Party:
 
         Example:
 
-                .. code-block:: python
-                    character = party.get_character_by_name("Sckricko")
-                    if character is not None:
-                        print(f"Character '{character.name}' has {character.hit_points} hit points.")
+        ```python
+        character = party.get_character_by_name("Sckricko")
+        if character is not None:
+            print(f"Character '{character.name}' has {character.hit_points} hit points.")
+        ```
 
         Args:
             name (str): The name of the character to return.
@@ -353,13 +363,14 @@ class Party:
 
         Example:
 
-            .. code-block:: python
-                if len(party.members) > 0:
-                    # Get the first character in the party
-                    first_character = party.get_character_by_index(0)
+        ```python
+        if len(party.members) > 0:
+            # Get the first character in the party
+            first_character = party.get_character_by_index(0)
 
-                    # Get the last character in the party
-                    last_character = party.get_character_by_index(-1)
+            # Get the last character in the party
+            last_character = party.get_character_by_index(-1)
+        ```
 
         Args:
             index (int): The index of the character to return.
@@ -377,10 +388,11 @@ class Party:
 
         Example:
 
-            .. code-block:: python
-                fighters = party.get_characters_by_class(character_classes.CharacterClassType.FIGHTER)
-                for fighter in fighters:
-                    print(fighter.name)
+        ```python
+        fighters = party.get_characters_by_class(character_classes.CharacterClassType.FIGHTER)
+        for fighter in fighters:
+            print(fighter.name)
+        ```
 
         Args:
             character_class (character_classes.CharacterClassType): The class of characters to return.
@@ -399,14 +411,15 @@ class Party:
 
         Example:
 
-                Get the index of a character in the party without checking whether the character is in the party (not
-                recommended):
+        Get the index of a character in the party without checking whether the character is in the party (not
+        recommended):
 
-                .. code-block:: python
-                    character = party.get_character_by_name("Sckricko")
-                    if party.is_member(character):
-                        index = party.get_character_index(character)
-                        print(f"Character '{character.name}' is number {index + 1} in the party's marching order.")
+        ```python
+        character = party.get_character_by_name("Sckricko")
+        if party.is_member(character):
+            index = party.get_character_index(character)
+            print(f"Character '{character.name}' is number {index + 1} in the party's marching order.")
+        ```
 
         Args:
             character (PlayerCharacter): The character to get the index of
@@ -438,11 +451,13 @@ class Party:
 
         Example:
 
-            .. code-block:: python
-                # Move a character from fourth in line (index 3) to the front of the party at index 0.
-                character = party.get_character_by_name("Sckricko")
-                if party.is_member(character):
-                    party.move_character_to_index(character, 0)
+        ```python
+        # Move a character from fourth in line (index 3) to the
+        # front of the party at index 0.
+        character = party.get_character_by_name("Sckricko")
+        if party.is_member(character):
+            party.move_character_to_index(character, 0)
+        ```
 
         Args:
             character (PlayerCharacter): The character to move.
@@ -478,10 +493,11 @@ class Party:
 
         Example:
 
-            Award experience points to the living characters in the party:
-
-            .. code-block:: python
-                party.award_xp(100)
+        ```python
+        # Award experience points to the
+        # living characters in the party
+        party.award_xp(100)
+        ```
 
         Args:
             xp (int): The number of experience points to award to each character in the party.

--- a/osrlib/osrlib/party.py
+++ b/osrlib/osrlib/party.py
@@ -1,5 +1,4 @@
-"""The party module contains the [Party][osrlib.party.Party] class and functions related to managing a party of player characters (collection
-of [PlayerCharacter][osrlib.player_character.PlayerCharacter])."""
+"""The party module contains the [Party][osrlib.party.Party] class and functions related to managing a party of player characters (collection of [PlayerCharacter][osrlib.player_character.PlayerCharacter])."""
 
 import random
 from typing import List
@@ -29,7 +28,6 @@ class CharacterAlreadyInPartyError(Exception):
     """Raised when attempting to add a player character to a party that already has that character as a member.
 
     Example:
-
     Before trying to add a character to a party, check whether the character is already in the party by using the in
     operator:
 
@@ -46,7 +44,6 @@ class CharacterNotInPartyError(Exception):
     """Raised when attempting to remove a player character from a party that does not have the character as a member.
 
     Example:
-
     Before trying to remove a character from a party, check whether the character is in the party by using the ``in``
     operator:
 
@@ -78,8 +75,8 @@ class Party:
 
     Args:
         name (str): The name of the party.
-        max_party_members (int): The maximum number of characters allowed in the party. Defaults to 6.
-        characters (List[PlayerCharacter]): The characters in the party. Defaults to an empty list.
+        max_party_members (int): The maximum number of characters allowed in the party.
+        characters (List[PlayerCharacter]): The characters in the party.
 
     Attributes:
         name (str): The name of the party.
@@ -88,7 +85,7 @@ class Party:
         active_character (PlayerCharacter): The currently active, or selected, character in the party.
         is_adventuring (bool): Whether the party has been added to an Adventure that has been started.
         current_adventure (Adventure): The adventure the party is currently in, or None if the party is not in an
-            adventure.
+                                       adventure.
     """
 
     def __init__(
@@ -147,8 +144,7 @@ class Party:
     def create_character(
         self, name: str, character_class: CharacterClassType, level: int = 1
     ) -> PlayerCharacter:
-        """Initialize a new character, add them to the party, set as the active character for the party, and return the
-        character.
+        """Initialize a new character, add them to the party, set as the active character for the party, and return the character.
 
         Example:
 
@@ -289,10 +285,9 @@ class Party:
         If the party has no members, the active character is set to None.
 
         Example:
-
-            ```python
-            party.set_next_character_as_active()
-            ```
+        ```python
+        party.set_next_character_as_active()
+        ```
         """
         if not self.members or len(self.members) == 0:
             # Handle the case where there are no members in the party
@@ -317,7 +312,6 @@ class Party:
         If the character is the last in the party, the party's active character is set to None.
 
         Example:
-
         ```python
         try:
             party.remove_character(character)
@@ -340,7 +334,6 @@ class Party:
         """Get a character from the party by name or None if the character is not in the party.
 
         Example:
-
         ```python
         character = party.get_character_by_name("Sckricko")
         if character is not None:
@@ -362,7 +355,6 @@ class Party:
         """Get a character from the party by index, or None if there's no character at that index.
 
         Example:
-
         ```python
         if len(party.members) > 0:
             # Get the first character in the party
@@ -387,7 +379,6 @@ class Party:
         """Get all characters in the party of the given class.
 
         Example:
-
         ```python
         fighters = party.get_characters_by_class(character_classes.CharacterClassType.FIGHTER)
         for fighter in fighters:
@@ -492,7 +483,6 @@ class Party:
         """Divide and award experience points to the living characters in the party.
 
         Example:
-
         ```python
         # Award experience points to the
         # living characters in the party
@@ -522,7 +512,8 @@ class Party:
         """
         return [character for character in self.members if character.is_alive]
 
-    def to_dict(self):
+    def to_dict(self) -> dict:
+        """Serializes the `Party` to a dictionary, typically in preparation for writing it to persistent storage in a downstream operation."""
         party_dict = {
             "characters": [character.to_dict() for character in self.members],
             "name": self.name,
@@ -530,7 +521,8 @@ class Party:
         return party_dict
 
     @classmethod
-    def from_dict(cls, party_dict: dict):
+    def from_dict(cls, party_dict: dict) -> "Party":
+        """Deserializes a dictionary representation of an `Exit` object. Typically done after getting the dictionary from persistent storage."""
         characters_from_dict = [
             PlayerCharacter.from_dict(character_dict)
             for character_dict in party_dict["characters"]


### PR DESCRIPTION
Most of the code examples need to be replaced with examples that are actually helpful and useful.

These modules should at least no longer throw `flake8-docstrings` linter errors, and the `dungeon` module has the start of a useful module docstring.