### PR TITLE
Party manager: character removal and marching order

### DIFF
--- a/osrgame/osrgame/screens/__init__.py
+++ b/osrgame/osrgame/screens/__init__.py
@@ -2,6 +2,7 @@
 
 from .camping import CampingScreen
 from .char_creation import CharCreationScreen
+from .confirm_modal import ConfirmModal
 from .combat import CombatScreen
 from .explore import ExploreScreen
 from .game_over import GameOverScreen
@@ -20,6 +21,7 @@ __all__ = [
     "CampingScreen",
     "CharCreationScreen",
     "CombatScreen",
+    "ConfirmModal",
     "ExploreScreen",
     "GameOverScreen",
     "InnScreen",

--- a/osrgame/osrgame/screens/camping.py
+++ b/osrgame/osrgame/screens/camping.py
@@ -76,7 +76,7 @@ class CampingScreen(Screen):
         """Push the party manager to reorder the party."""
         from .party_manager import PartyManagerScreen
 
-        self.app.push_screen(PartyManagerScreen(), callback=self._on_watch_return)
+        self.app.push_screen(PartyManagerScreen(allow_drop=False), callback=self._on_watch_return)
 
     def _on_watch_return(self, result=None) -> None:
         """Refresh roster when returning from watch order."""

--- a/osrgame/osrgame/screens/confirm_modal.py
+++ b/osrgame/osrgame/screens/confirm_modal.py
@@ -1,0 +1,77 @@
+"""Reusable confirmation modal dialog."""
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+
+
+class ConfirmModal(ModalScreen[bool]):
+    """Modal confirmation dialog with Yes/No buttons.
+
+    Push with a callback to get the result:
+
+        self.app.push_screen(ConfirmModal("Delete?", title="Confirm"), callback=handler)
+    """
+
+    DEFAULT_CSS = """
+    ConfirmModal {
+        align: center middle;
+    }
+
+    #confirm-dialog {
+        width: 50;
+        height: auto;
+        padding: 1 2;
+        border: solid #4a4a8a;
+        background: #0e0e3a;
+    }
+
+    #confirm-title {
+        text-align: center;
+        color: #ffd700;
+        text-style: bold;
+        margin-bottom: 1;
+    }
+
+    #confirm-message {
+        color: #c0c0c0;
+        margin-bottom: 1;
+    }
+
+    #confirm-buttons {
+        align: center middle;
+        height: auto;
+    }
+
+    #confirm-buttons Button {
+        margin: 0 2;
+        min-width: 12;
+    }
+    """
+
+    BINDINGS = [
+        ("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, message: str, title: str = "Confirm", **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._message = message
+        self._title = title
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="confirm-dialog"):
+            yield Static(self._title, id="confirm-title")
+            yield Static(self._message, id="confirm-message")
+            with Horizontal(id="confirm-buttons"):
+                yield Button("No", id="btn-confirm-no", variant="primary")
+                yield Button("Yes", id="btn-confirm-yes", variant="error")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn-confirm-yes":
+            self.dismiss(True)
+        else:
+            self.dismiss(False)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)

--- a/osrgame/osrgame/screens/party_manager.py
+++ b/osrgame/osrgame/screens/party_manager.py
@@ -2,40 +2,136 @@
 
 from textual import on
 from textual.app import ComposeResult
-from textual.containers import Vertical
+from textual.containers import Horizontal, Vertical
 from textual.screen import Screen
 from textual.widgets import Button, Footer, Header, Static
 
-from ..widgets import PartyRosterWidget
+from ..widgets import CharSheetWidget, PartyRosterWidget
+from .confirm_modal import ConfirmModal
 
 
 class PartyManagerScreen(Screen):
-    """View party members, reorder, and manage the roster."""
+    """View party members, reorder marching order, and drop characters."""
 
     BINDINGS = [
         ("escape", "done", "Done"),
     ]
 
+    def __init__(self, allow_drop: bool = True, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self._allow_drop = allow_drop
+        self._selected_index: int | None = None
+
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
-        yield PartyRosterWidget(id="party-mgr-roster")
-        yield Vertical(
-            Static(
-                "Party manager — select a character to view details",
-                classes="gold-heading",
-            ),
-            id="party-mgr-details",
-        )
-        with Vertical(id="party-mgr-actions"):
-            yield Button("Done", id="btn-done", variant="primary")
+        yield Static("Party manager", id="town-title", classes="gold-heading")
+        with Horizontal(id="party-mgr-layout"):
+            with Vertical(id="party-mgr-left"):
+                yield PartyRosterWidget(id="party-mgr-roster")
+                with Horizontal(id="party-mgr-actions"):
+                    yield Button("Move up", id="btn-move-up", disabled=True)
+                    yield Button("Move down", id="btn-move-down", disabled=True)
+                    if self._allow_drop:
+                        yield Button(
+                            "Drop character",
+                            id="btn-drop-char",
+                            variant="error",
+                            disabled=True,
+                        )
+                    yield Button("Done", id="btn-done", variant="primary")
+            yield CharSheetWidget(id="party-mgr-sheet")
         yield Footer()
 
     def on_mount(self) -> None:
         self.query_one("#party-mgr-roster", PartyRosterWidget).refresh_roster()
+
+    def _get_party_members(self) -> list:
+        return self.app.game_state.adventure.active_party.members
+
+    def _update_button_states(self) -> None:
+        """Enable/disable buttons based on current selection."""
+        members = self._get_party_members()
+        has_selection = self._selected_index is not None
+        count = len(members)
+
+        self.query_one("#btn-move-up", Button).disabled = (
+            not has_selection or self._selected_index == 0
+        )
+        self.query_one("#btn-move-down", Button).disabled = (
+            not has_selection or self._selected_index == count - 1
+        )
+        drop_btn = self.query_one_optional("#btn-drop-char", Button)
+        if drop_btn is not None:
+            drop_btn.disabled = not has_selection
+
+    def on_data_table_row_selected(self, event) -> None:
+        """Show character sheet when a roster row is clicked."""
+        event.stop()
+        members = self._get_party_members()
+        if event.cursor_row < len(members):
+            self._selected_index = event.cursor_row
+            pc = members[self._selected_index]
+            self.query_one("#party-mgr-sheet", CharSheetWidget).update_character(pc)
+            self._update_button_states()
+
+    @on(Button.Pressed, "#btn-move-up")
+    def move_up(self) -> None:
+        if self._selected_index is None or self._selected_index == 0:
+            return
+        party = self.app.game_state.adventure.active_party
+        pc = party.members[self._selected_index]
+        new_index = self._selected_index - 1
+        party.move_character_to_index(pc, new_index)
+        self._selected_index = new_index
+        roster = self.query_one("#party-mgr-roster", PartyRosterWidget)
+        roster.refresh_roster()
+        roster.move_cursor(row=new_index)
+        self._update_button_states()
+
+    @on(Button.Pressed, "#btn-move-down")
+    def move_down(self) -> None:
+        members = self._get_party_members()
+        if self._selected_index is None or self._selected_index >= len(members) - 1:
+            return
+        party = self.app.game_state.adventure.active_party
+        pc = party.members[self._selected_index]
+        new_index = self._selected_index + 1
+        party.move_character_to_index(pc, new_index)
+        self._selected_index = new_index
+        roster = self.query_one("#party-mgr-roster", PartyRosterWidget)
+        roster.refresh_roster()
+        roster.move_cursor(row=new_index)
+        self._update_button_states()
+
+    @on(Button.Pressed, "#btn-drop-char")
+    def drop_character(self) -> None:
+        if self._selected_index is None:
+            return
+        pc = self._get_party_members()[self._selected_index]
+        self.app.push_screen(
+            ConfirmModal(
+                f"Permanently remove {pc.name} from the party? This cannot be undone.",
+                title="Drop character",
+            ),
+            callback=self._on_drop_confirmed,
+        )
+
+    def _on_drop_confirmed(self, confirmed: bool) -> None:
+        if not confirmed or self._selected_index is None:
+            return
+        party = self.app.game_state.adventure.active_party
+        pc = party.members[self._selected_index]
+        name = pc.name
+        party.remove_character(pc)
+        self.notify(f"{name} has been removed from the party.", title="Character dropped")
+        self._selected_index = None
+        self.query_one("#party-mgr-roster", PartyRosterWidget).refresh_roster()
+        self.query_one("#party-mgr-sheet", CharSheetWidget).update_character(None)
+        self._update_button_states()
 
     @on(Button.Pressed, "#btn-done")
     def done(self) -> None:
         self.action_done()
 
     def action_done(self) -> None:
-        self.app.pop_screen()
+        self.dismiss()

--- a/osrgame/osrgame/screens/town_training.py
+++ b/osrgame/osrgame/screens/town_training.py
@@ -27,7 +27,7 @@ class TrainingHallScreen(Screen):
                         "Create character", id="btn-create-char", variant="primary"
                     )
                     yield Button("Level up", id="btn-level-up")
-                    yield Button("Manage order", id="btn-manage-order")
+                    yield Button("Manage party", id="btn-manage-order")
                     yield Button("Done", id="btn-done")
             yield CharSheetWidget(id="training-sheet")
         yield Footer()
@@ -74,7 +74,11 @@ class TrainingHallScreen(Screen):
     def manage_order(self) -> None:
         from .party_manager import PartyManagerScreen
 
-        self.app.push_screen(PartyManagerScreen())
+        self.app.push_screen(PartyManagerScreen(), callback=self._on_manage_return)
+
+    def _on_manage_return(self, result=None) -> None:
+        """Refresh roster when returning from party manager (character may have been dropped)."""
+        self.query_one("#training-roster", PartyRosterWidget).refresh_roster()
 
     @on(Button.Pressed, "#btn-done")
     def done(self) -> None:

--- a/osrgame/osrgame/styles/app.tcss
+++ b/osrgame/osrgame/styles/app.tcss
@@ -227,29 +227,3 @@ GameOverScreen {
     margin-bottom: 2;
 }
 
-/* Party manager screen */
-
-PartyManagerScreen {
-    layout: grid;
-    grid-size: 2;
-    grid-columns: 1fr 1fr;
-    grid-rows: 1fr auto;
-}
-
-#party-mgr-roster {
-    border: solid #4a4a8a;
-    background: #0e0e3a;
-}
-
-#party-mgr-details {
-    border: solid #4a4a8a;
-    background: #0e0e3a;
-    padding: 1;
-}
-
-#party-mgr-actions {
-    column-span: 2;
-    height: auto;
-    align: center middle;
-    padding: 1;
-}

--- a/osrgame/osrgame/styles/character.tcss
+++ b/osrgame/osrgame/styles/character.tcss
@@ -66,6 +66,40 @@ TrainingHallScreen {
     margin: 0 1;
 }
 
+/* Party manager */
+
+PartyManagerScreen {
+    background: #0a0a2e;
+}
+
+#party-mgr-layout {
+    height: 1fr;
+}
+
+#party-mgr-left {
+    width: 50%;
+}
+
+#party-mgr-roster {
+    height: 1fr;
+    border: solid #4a4a8a;
+    background: #0e0e3a;
+}
+
+#party-mgr-sheet {
+    width: 50%;
+}
+
+#party-mgr-actions {
+    height: auto;
+    align: center middle;
+    padding: 1;
+}
+
+#party-mgr-actions Button {
+    margin: 0 1;
+}
+
 /* Level up */
 
 LevelUpScreen {

--- a/osrgame/osrgame/widgets/char_sheet.py
+++ b/osrgame/osrgame/widgets/char_sheet.py
@@ -37,8 +37,18 @@ class CharSheetWidget(Vertical):
         inv = self.query_one("#char-inventory", DataTable)
         inv.add_columns("Item", "Type", "Equipped", "GP")
 
-    def update_character(self, pc: PlayerCharacter) -> None:
-        """Refresh all sub-tables from a PlayerCharacter instance."""
+    def update_character(self, pc: PlayerCharacter | None) -> None:
+        """Refresh all sub-tables from a PlayerCharacter instance.
+
+        Pass ``None`` to reset the widget to its empty state.
+        """
+        if pc is None:
+            self.query_one("#char-header", Static).update("No character selected")
+            self.query_one("#char-abilities", DataTable).clear()
+            self.query_one("#char-saves", DataTable).clear()
+            self.query_one("#char-inventory", DataTable).clear()
+            return
+
         # Header
         header = self.query_one("#char-header", Static)
         alignment = getattr(pc, "alignment", None)


### PR DESCRIPTION
## Summary

- Add reusable `ConfirmModal` dialog (`ModalScreen[bool]`) for destructive action confirmation
- Rewrite `PartyManagerScreen` with full roster + char sheet split layout, move up/down/drop buttons
- `allow_drop` parameter hides the drop button during camping (reorder-only context)
- `CharSheetWidget.update_character()` now accepts `None` to reset to empty state
- Training hall "Manage order" renamed to "Manage party" with roster refresh callback on return

## Test plan

- [x] All 370 tests pass, lint clean
- [x] Launch TUI, create 2+ characters, open Training Hall > "Manage party"
- [x] Verify roster + char sheet layout, click character to populate sheet
- [x] Move up/down — order changes, cursor follows, buttons disable at boundaries
- [x] Drop character — modal appears, "No" cancels, "Yes" removes with notification
- [x] Return to Training Hall — roster reflects changes
- [x] Enter dungeon, camp, "Watch order" — no "Drop character" button visible